### PR TITLE
Reproduce desk #18521

### DIFF
--- a/samples/fullduplex/Core_6/Client/Program.cs
+++ b/samples/fullduplex/Core_6/Client/Program.cs
@@ -21,6 +21,9 @@ class Program
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.SendFailedMessagesTo("error");
+        endpointConfiguration.SetConventions();
+
+        endpointConfiguration.Routing().RouteToEndpoint(typeof(RequestDataMessage), "Samples.FullDuplex.Server");
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);
@@ -43,12 +46,11 @@ class Program
                 var guid = Guid.NewGuid();
                 Console.WriteLine($"Requesting to get data by id: {guid.ToString("N")}");
 
-                var message = new RequestDataMessage
+                await endpointInstance.Send<RequestDataMessage>(message =>
                 {
-                    DataId = guid,
-                    String = "String property value"
-                };
-                await endpointInstance.Send("Samples.FullDuplex.Server", message)
+                    message.DataId = guid;
+                    message.String = "String property value";
+                })
                     .ConfigureAwait(false);
             }
 

--- a/samples/fullduplex/Core_6/Server/Program.cs
+++ b/samples/fullduplex/Core_6/Server/Program.cs
@@ -21,6 +21,7 @@ class Program
         endpointConfiguration.UsePersistence<InMemoryPersistence>();
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.SendFailedMessagesTo("error");
+        endpointConfiguration.SetConventions();
 
         var endpointInstance = await Endpoint.Start(endpointConfiguration)
             .ConfigureAwait(false);

--- a/samples/fullduplex/Core_6/Server/RequestDataMessageHandler.cs
+++ b/samples/fullduplex/Core_6/Server/RequestDataMessageHandler.cs
@@ -16,13 +16,11 @@ public class RequestDataMessageHandler : IHandleMessages<RequestDataMessage>
 
         #region DataResponseReply
 
-        var response = new DataResponseMessage
+        await context.Reply<DataResponseMessage>(response =>
         {
-            DataId = message.DataId,
-            String = message.String
-        };
-
-        await context.Reply(response)
+            response.DataId = message.DataId;
+            response.String = message.String;
+        })
             .ConfigureAwait(false);
 
         #endregion

--- a/samples/fullduplex/Core_6/Shared/Conventions.cs
+++ b/samples/fullduplex/Core_6/Shared/Conventions.cs
@@ -1,0 +1,15 @@
+using System.Reflection;
+using NServiceBus;
+
+public static class Conventions
+{
+    public static void SetConventions(this EndpointConfiguration instance)
+    {
+        var asm = Assembly.GetExecutingAssembly();
+
+        var c = instance.Conventions();
+        c.DefiningMessagesAs(t => t.Name.EndsWith("Message") && t.Assembly == asm);
+        c.DefiningCommandsAs(t => t.Name.EndsWith("Command") && t.Assembly == asm);
+        c.DefiningEventsAs(t => t.Name.EndsWith("Event") && t.Assembly == asm);
+    }
+}

--- a/samples/fullduplex/Core_6/Shared/DataResponseMessage.cs
+++ b/samples/fullduplex/Core_6/Shared/DataResponseMessage.cs
@@ -1,9 +1,9 @@
-using NServiceBus;
 using System;
+
 #region ResponseMessage
-public class DataResponseMessage : IMessage
+public interface DataResponseMessage
 {
-    public Guid DataId { get; set; }
-    public string String { get; set; }
+    Guid DataId { get; set; }
+    string String { get; set; }
 }
 #endregion

--- a/samples/fullduplex/Core_6/Shared/RequestDataMessage.cs
+++ b/samples/fullduplex/Core_6/Shared/RequestDataMessage.cs
@@ -1,10 +1,9 @@
 using System;
-using NServiceBus;
 
 #region RequestMessage
-public class RequestDataMessage : IMessage
+public interface RequestDataMessage
 {
-    public Guid DataId { get; set; }
-    public string String { get; set; }
+    Guid DataId { get; set; }
+    string String { get; set; }
 }
 #endregion

--- a/samples/fullduplex/Core_6/Shared/Shared.csproj
+++ b/samples/fullduplex/Core_6/Shared/Shared.csproj
@@ -36,6 +36,7 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Conventions.cs" />
     <Compile Include="DataResponseMessage.cs" />
     <Compile Include="RequestDataMessage.cs" />
   </ItemGroup>


### PR DESCRIPTION
Modification of sample to reproduce https://nservicebus.desk.com/agent/case/18521
## Issue

This sample uses interfaces instead of classes for messages. The routing fails when using interfaces with the following message:

> Unhandled Exception: System.Exception: Could not find metadata for 'RequestDataMessage__impl'.
> Ensure the following:
> 1. 'RequestDataMessage__impl' is included in initial scanning.
> 2. 'RequestDataMessage__impl' implements either 'IMessage', 'IEvent' or 'ICommand' or alternatively, if you don't want to implement an interface, you can use 'Unobtrusive Mode'.
## Exception

This reproduction results in the following exception:

``````
Unhandled Exception: System.Exception: Could not find metadata for 'RequestDataMessage__impl'.
Ensure the following:
1. 'RequestDataMessage__impl' is included in initial scanning.
2. 'RequestDataMessage__impl' implements either 'IMessage', 'IEvent' or 'ICommand' or alternatively, if you don't want to implement an interface, you can use 'Unobtrusive Mode'.
   at NServiceBus.Unicast.Messages.MessageMetadataRegistry.GetMessageMetadata(Type messageType) in C:\Build\src\NServiceBus.Core\Unicast\Messages\MessageMetadat                                                                                  aRegistry.cs:line 25
   at NServiceBus.UnicastRouter.<Route>d__1.MoveNext() in C:\Build\src\NServiceBus.Core\Routing\UnicastRouter.cs:line 25
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at NServiceBus.UnicastSendRouterConnector.<Invoke>d__2.MoveNext() in C:\Build\src\NServiceBus.Core\Routing\Routers\UnicastSendRouterConnector.cs:line 51
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult()
   at Program.<AsyncMain>d__1.MoveNext() in S:\particular\docs.particular.net\samples\fullduplex\Core_6\Client\Program.cs:line 49
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at Program.<AsyncMain>d__1.MoveNext() in S:\particular\docs.particular.net\samples\fullduplex\Core_6\Client\Program.cs:line 63
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.CompilerServices.TaskAwaiter.ThrowForNonSuccess(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Runtime.CompilerServices.TaskAwaiter.GetResult()
   at Program.Main() in S:\particular\docs.particular.net\samples\fullduplex\Core_6\Client\Program.cs:line 11```
``````
